### PR TITLE
service name should match the instructions in wiki

### DIFF
--- a/hello-spring-mongodb/src/main/resources/root-context.xml
+++ b/hello-spring-mongodb/src/main/resources/root-context.xml
@@ -11,18 +11,18 @@
 
 	<bean id="mongoTemplate" class="org.springframework.data.document.mongodb.MongoTemplate">
     	<constructor-arg ref="mongo"/>
-    	<constructor-arg name="databaseName" value="#{serviceProperties['mongodb-hello-mongo.db']}"/>
+    	<constructor-arg name="databaseName" value="#{serviceProperties['mongodb-hello.db']}"/>
     	<constructor-arg name="defaultCollectionName" value="person"/>
-    	<property name="username" value="#{serviceProperties['mongodb-hello-mongo.username']}"/>    	
-    	<property name="password" value="#{serviceProperties['mongodb-hello-mongo.password']}"/>     	
+    	<property name="username" value="#{serviceProperties['mongodb-hello.username']}"/>    	
+    	<property name="password" value="#{serviceProperties['mongodb-hello.password']}"/>     	
   	</bean>
   	
 	<beans profile="default">
 		<bean id="mongo" class="com.mongodb.Mongo"/>
 		<util:properties id="serviceProperties">		
-			<prop key="mongodb-hello-mongo.db">pwdtest</prop>
-			<prop key="mongodb-hello-mongo.username">test_user</prop>
-			<prop key="mongodb-hello-mongo.password">efgh</prop>
+			<prop key="mongodb-hello.db">pwdtest</prop>
+			<prop key="mongodb-hello.username">test_user</prop>
+			<prop key="mongodb-hello.password">efgh</prop>
 		</util:properties>
 	</beans>
         


### PR DESCRIPTION
need to s/mongodb-hello-mongo/mongodb-hello/ in order to be consistent with the getting started instructions and screenshots (https://github.com/SpringSource/cloudfoundry-samples/wiki/Spring-Hello-MongoDB-Sample-Application)

Currently, since service name is not updated, the application throws error when trying to start
Error: Application 'samples-spring's state is undetermined, not enough information available.

The logs complain about null argument being passed to constructor of the class org.springframework.data.document.mongodb.MongoTemplate
