### PR TITLE
Remove serverURL from config.

### DIFF
--- a/petclinic-grails/grails-app/conf/Config.groovy
+++ b/petclinic-grails/grails-app/conf/Config.groovy
@@ -32,13 +32,6 @@ grails.converters.encoding="UTF-8"
 // enabled native2ascii conversion of i18n properties files
 grails.enable.native2ascii = true
 
-// set per-environment serverURL stem for creating absolute links
-environments {
-    production {
-        grails.serverURL = "http://www.changeme.com"
-    }
-}
-
 // log4j configuration
 log4j = {
     error  'org.codehaus.groovy.grails.web.servlet',  //  controllers


### PR DESCRIPTION
Remove the grails.serverURL setting from Config.groovy. In Grails 2.0, the redirect() method in a controller uses this value to build absolute URLs. In this app, this was causing the user to be sent to a bad "www.changeme.com" URL on redirects. 
