### PR TITLE
added warning that bash completion script needs to be updated for vmc changes

### DIFF
--- a/bash-completion/README.md
+++ b/bash-completion/README.md
@@ -2,7 +2,7 @@
 
 This is a bash completion script for the Cloud Foundry command-line utility vmc.
 
-### Update: 03/21/13 - This script needs to be updated to reflect various changes to vmc (including the renaming of "vmc" to "cf" for talking to v2 CF components)
+### Update: 03/21/13 - This script needs to be updated to reflect various changes to vmc (including the renaming of "vmc" to "cf" for the version that can talk to v2 CF components)
 
 ### Installation
 


### PR DESCRIPTION
Added warning that the bash completion tool for vmc needs to be updated for vmc changes (such as change of "vmc" to "cf"). Apologies for not updating the script directly.
