### PR TITLE
fix for java.io.FileNotFoundException: /WEB-INF/retwis.log (No such file or directory) error in Tomcat

### DIFF
--- a/retwisj/src/main/resources/log4j.properties
+++ b/retwisj/src/main/resources/log4j.properties
@@ -7,7 +7,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
 
 log4j.appender.logfile=org.apache.log4j.RollingFileAppender
-log4j.appender.logfile.File=${retwis.root}/WEB-INF/retwis.log
+#log4j.appender.logfile.File=${retwis.root}/WEB-INF/retwis.log
 log4j.appender.logfile.MaxFileSize=512KB
 # Keep three backup files.
 log4j.appender.logfile.MaxBackupIndex=3


### PR DESCRIPTION
During deployment of war file in Tomcat, the application tries to create /WEB-INF/retwis.log due to existing log4j configuration. Following line is commented in log4j.properties to prevent this error: 

log4j.appender.logfile.File=${retwis.root}/WEB-INF/retwis.log
